### PR TITLE
VG-4799 Add additional error text

### DIFF
--- a/app/common/util/query-builder.js
+++ b/app/common/util/query-builder.js
@@ -109,7 +109,7 @@ angular.module('voyager.util').
             return queryString;
         }
 
-        function build2(solrParams, page, itemsPerPage, sortDirection, sortField) {
+        function build2(solrParams, page, itemsPerPage, sortDirection, sortField, disableJSONP) {
             var placeFilter = '';
             if(solrParams) {
                 delete solrParams.fq; //filter service will apply filter params below
@@ -143,7 +143,11 @@ angular.module('voyager.util').
                 queryString += '&sort=' + sortField + ' ' + sortDirection;
             }
             queryString += '&rand=' + Math.random(); // avoid browser caching?
-            queryString += '&wt=json&json.wrf=JSON_CALLBACK';
+            queryString += '&wt=json';
+
+            if (!disableJSONP) {
+                queryString += '&json.wrf=JSON_CALLBACK';
+            }
 
             return queryString;
         }
@@ -195,8 +199,8 @@ angular.module('voyager.util').
 
         return {
 
-            doBuild2: function (params, page, itemsPerPage, sortDirection, sortField) {
-                return build2(params, page, itemsPerPage, sortDirection, sortField);
+            doBuild2: function (params, page, itemsPerPage, sortDirection, sortField, disableJSONP) {
+                return build2(params, page, itemsPerPage, sortDirection, sortField, disableJSONP);
             },
 
             doByIds: function (ids) {

--- a/app/src/search/results-header.html
+++ b/app/src/search/results-header.html
@@ -1,7 +1,7 @@
 <!-- header: results count and sort and filters -->
 <div class="alert alert-warning warning alert-dismissible" role="alert" ng-show="searchError">
     <a href="#" class="icon-x close" data-dismiss="alert" ng-click="hideSearchError($event)"><span class="sr-only">Close</span></a>
-    <span class="icon-error"></span> Search Failed.  One or more fields do not exist for this saved search.
+    <span class="icon-error"></span>{{searchErrorReason}}
 </div>
 
 <div class="alert alert-warning warning alert-dismissible" role="alert" ng-if="resultError">

--- a/app/src/search/results-header.html
+++ b/app/src/search/results-header.html
@@ -1,7 +1,7 @@
 <!-- header: results count and sort and filters -->
 <div class="alert alert-warning warning alert-dismissible" role="alert" ng-show="searchError">
     <a href="#" class="icon-x close" data-dismiss="alert" ng-click="hideSearchError($event)"><span class="sr-only">Close</span></a>
-    <span class="icon-error"></span> Search Failed
+    <span class="icon-error"></span> Search Failed.  One or more fields do not exist for this saved search.
 </div>
 
 <div class="alert alert-warning warning alert-dismissible" role="alert" ng-if="resultError">

--- a/app/src/search/search-controller.js
+++ b/app/src/search/search-controller.js
@@ -162,6 +162,14 @@ angular.module('voyager.search')
 			});
 		}
 
+		function _formatErrorReason(error) {
+			var reason = 'Search failed.';
+			if (error && (error.msg || '').toLowerCase().indexOf('undefined field') > -1) {
+				reason += ' One or more fields do not exist for this saved search.';
+			}
+			return reason;
+		}
+
 		function _handleSearchError(res) {
 			searchScroll.setPosition(0);
 			$scope.eof = false;
@@ -172,6 +180,7 @@ angular.module('voyager.search')
 			_searching = false;
 			_initializing = false;
 			$scope.searchError = true;
+			$scope.searchErrorReason = _formatErrorReason((res.data||{}).error);
 			res.data = {response:{docs:[]}};
 			$scope.$emit('searchComplete', res.data); //so table view updates
 			_setPageClass();
@@ -413,14 +422,14 @@ angular.module('voyager.search')
         $scope.exportResultsList = function() {
             searchModalService.exportResultsList($scope);
         };
-        
+
         //Handle search result with error
         $scope.hideResultErrorMessage = function($event) {
             $event.preventDefault();
             $scope.resultError = false;
             _setPageClass();
         };
-        
+
 		$scope.showResultErrorTrace = function() {
 			searchModalService.showResultErrorTrace($scope.resultStackTrace);
 		};
@@ -465,7 +474,7 @@ angular.module('voyager.search')
             $scope.searchError = false;
             _setPageClass();
         };
-        
+
 		function _setPageClass() {
 			var _pageClass = searchViewService.getPageClass($scope.filterVisible, $scope.view, $scope.pageFramework.showMap, $scope.searchError, $scope.resultError);
 			$scope.mapWrapperClass = _pageClass.mapWrapperClass;

--- a/app/src/search/search-service.js
+++ b/app/src/search/search-service.js
@@ -56,6 +56,15 @@ angular.module('voyager.search').
             });
         }
 
+//        function appendTransform(defaults, transform) {
+//            defaults = angular.isArray(defaults) ? defaults : [defaults];
+//            return defaults.concat(transform);
+//        }
+
+//        $jsonpCallbacks.getResponse = function(callbackPath) {
+//            console.log(callbackPath);
+//        };
+
 //        function _featureGroupVisitor(featureGroups, doc) {
 //            if(angular.isDefined(doc.tag_flags)) {
 //                doc.featureGroup = featureGroups[doc.tag_flags[0]];
@@ -69,12 +78,12 @@ angular.module('voyager.search').
         return {
             doSearch2: function (params, append) {
                 _setParams(params);
-                var service = queryBuilder.doBuild2(_searchParams, _page, _itemsPerPage, _sortDirection, _sortField);
+                var service = queryBuilder.doBuild2(_searchParams, _page, _itemsPerPage, _sortDirection, _sortField, true);
                 _solrService = service;
                 var solrPage = service.substring(service.indexOf('solr')-1);
                 urlUtil.buildSearchUrl2(_searchParams, _page, getMapView(params.vw), params.view, _sortField); //keeps the url in sync
                 var startTime = Date.now();
-                return $http.jsonp(service).success(function (data) {
+                return $http.get(service).success(function (data) {
                     var endTime = Date.now() - startTime;
                     _lastResult = data;
                     if(!append) {

--- a/app/src/search/search-service.js
+++ b/app/src/search/search-service.js
@@ -56,15 +56,6 @@ angular.module('voyager.search').
             });
         }
 
-//        function appendTransform(defaults, transform) {
-//            defaults = angular.isArray(defaults) ? defaults : [defaults];
-//            return defaults.concat(transform);
-//        }
-
-//        $jsonpCallbacks.getResponse = function(callbackPath) {
-//            console.log(callbackPath);
-//        };
-
 //        function _featureGroupVisitor(featureGroups, doc) {
 //            if(angular.isDefined(doc.tag_flags)) {
 //                doc.featureGroup = featureGroups[doc.tag_flags[0]];

--- a/test/spec/search/search-controller-spec.js
+++ b/test/spec/search/search-controller-spec.js
@@ -50,7 +50,7 @@ describe('SearchCtrl', function () {
 
         //$http.expectGET(new RegExp('auth')).respond(authResponse); //auth info call
         if (search) {
-            $http.expectJSONP(new RegExp('solr\/v0')).respond(response);  //search call
+            $http.expectGET(new RegExp('solr\/v0')).respond(response);  //search call
             $http.flush();
         }
         scope.$apply();
@@ -61,7 +61,7 @@ describe('SearchCtrl', function () {
     describe('Load', function () {
 
         it('should load with empty results', function () {
-            
+
             scope.pageFramework = { showHeaderInfo: false };
 
             location.search({pg:2, disp:'disp', sort:'field asc'});
@@ -87,7 +87,7 @@ describe('SearchCtrl', function () {
             controllerService('SearchCtrl', {$scope: scope});
 
             //$http.expectGET(new RegExp('auth')).respond({}); //auth info call
-            $http.expectJSONP(new RegExp('solr\/v0')).respond(500,'');  //search call
+            $http.expectGET(new RegExp('solr\/v0')).respond(500,'');  //search call
 
             scope.$apply();
             $http.flush();
@@ -297,7 +297,7 @@ describe('SearchCtrl', function () {
 
             initCtrl({response: response}, true);
 
-            $http.expectJSONP(new RegExp('solr\/v0')).respond({response:response});  //search call next chunk (page)
+            $http.expectGET(new RegExp('solr\/v0')).respond({response:response});  //search call next chunk (page)
 
             $($window).trigger('scroll');
 
@@ -338,7 +338,7 @@ describe('SearchCtrl', function () {
 
             expect(scope.bigMap).toBeFalsy();
         });
-        
+
         it('should change map size to small', function () {
 
             var response = {docs:[], numFound:0}, sort = {key:'key', value:'value'};


### PR DESCRIPTION
Simply added additional error text based on the ticket.  

Does it make sense to try to link the error text to the JSONP response error?  Additional work would be necessary to override the default JSONP error handling, because it doesn't provide the response data to the search service error handler.

```
"error": {
    "metadata": [
        "error-class",
        "org.apache.solr.common.SolrException",
        "root-error-class",
        "org.apache.solr.common.SolrException"
    ],
    "msg": "undefined field {fieldFilterName}",
    "code": 400
}
```