### PR TITLE
VG-4941: Quick Links That Don't Have A Category Set Don't Work

### DIFF
--- a/app/src/home/quick-links.html
+++ b/app/src/home/quick-links.html
@@ -1,18 +1,18 @@
 <section class="quick-links collections col-md-3 col-sm-4 col-xs-12 pull-right">
     <header>
-        <h1>{{$ctrl.title}}</h1>
+        <h1>{{vm.title}}</h1>
     </header>
-    <ul ng-if="$ctrl.categories.length == 0">
-        <li ng-repeat="item in ::$ctrl.list">
-            <a href="javascript:;" class="icon-collection" ng-click="applyCollection(item)">
+    <ul ng-if="vm.categories.length == 0">
+        <li ng-repeat="item in ::vm.list">
+            <a href="javascript:;" class="icon-collection" ng-click="vm.applyCollection(item)">
                 {{::item.title}}<span>{{::item.count | number}} item{{::item.count > 1 ? "s" : ""}}</span>
             </a>
         </li>
     </ul>
-    <div ng-if="$ctrl.categories.length > 0" class="panel panel-primary" ng-repeat="category in $ctrl.categories" aria-hidden="false">
+    <div ng-if="vm.categories.length > 0" class="panel panel-primary" ng-repeat="category in vm.categories" aria-hidden="false">
         <div class="panel-heading" ng-class="category.displayState == 'in' ? 'selected' : ''">
             <h4 class="panel-title">
-                <a data-toggle="collapse" target="_self" href="#{{category.key}}" ng-click="$ctrl.toggleDisplayState(category)">
+                <a data-toggle="collapse" target="_self" href="#{{category.key}}" ng-click="vm.toggleDisplayState(category)">
                     {{category.key}} <i class="fa" ng-class="category.displayState == 'in' ? 'fa-angle-up' : 'fa-angle-down'"></i>
                 </a>
             </h4>
@@ -21,7 +21,7 @@
             <div class="panel-body">
                 <div ng-repeat="item in category.list">
                     <div>
-                        <a href="javascript:;" ng-click="$ctrl.applyCollection(item)" class="underline ng-scope">
+                        <a href="javascript:;" ng-click="vm.applyCollection(item)" class="underline ng-scope">
                             <span class="text ng-binding">
                                 {{item.title}}
                                 <span class="facet_count ng-binding" aria-hidden="false"> ({{item.count}} items)</span>

--- a/app/src/home/quick-links.html
+++ b/app/src/home/quick-links.html
@@ -1,35 +1,35 @@
 <section class="quick-links collections col-md-3 col-sm-4 col-xs-12 pull-right">
-    <header>
-        <h1>{{vm.title}}</h1>
-    </header>
-    <ul ng-if="vm.categories.length == 0">
-        <li ng-repeat="item in ::vm.list">
-            <a href="javascript:;" class="icon-collection" ng-click="vm.applyCollection(item)">
-                {{::item.title}}<span>{{::item.count | number}} item{{::item.count > 1 ? "s" : ""}}</span>
-            </a>
-        </li>
-    </ul>
-    <div ng-if="vm.categories.length > 0" class="panel panel-primary" ng-repeat="category in vm.categories" aria-hidden="false">
-        <div class="panel-heading" ng-class="category.displayState == 'in' ? 'selected' : ''">
-            <h4 class="panel-title">
-                <a data-toggle="collapse" target="_self" href="#{{category.key}}" ng-click="vm.toggleDisplayState(category)">
-                    {{category.key}} <i class="fa" ng-class="category.displayState == 'in' ? 'fa-angle-up' : 'fa-angle-down'"></i>
-                </a>
-            </h4>
-        </div>
-        <div id="{{category.key}}" class="panel-collapse collapse facet-types {{category.displayState}}">
-            <div class="panel-body">
-                <div ng-repeat="item in category.list">
-                    <div>
-                        <a href="javascript:;" ng-click="vm.applyCollection(item)" class="underline ng-scope">
-                            <span class="text ng-binding">
-                                {{item.title}}
-                                <span class="facet_count ng-binding" aria-hidden="false"> ({{item.count}} items)</span>
-                            </span>
-                        </a>
-                    </div>
-                </div>
-            </div>
-        </div>
+  <header>
+    <h1>{{vm.title}}</h1>
+  </header>
+  <ul ng-if="vm.categories.length == 0">
+    <li ng-repeat="item in ::vm.list">
+      <a href="javascript:;" class="icon-collection" ng-click="vm.applyCollection(item)">
+        {{::item.title}}<span>{{::item.count | number}} item{{::item.count > 1 ? "s" : ""}}</span>
+      </a>
+    </li>
+  </ul>
+  <div ng-if="vm.categories.length > 0" class="panel panel-primary" ng-repeat="category in vm.categories" aria-hidden="false">
+    <div class="panel-heading" ng-class="category.displayState == 'in' ? 'selected' : ''">
+      <h4 class="panel-title">
+        <a data-toggle="collapse" target="_self" href="#{{category.key}}" ng-click="vm.toggleDisplayState(category)">
+          {{category.key}} <i class="fa" ng-class="category.displayState == 'in' ? 'fa-angle-up' : 'fa-angle-down'"></i>
+        </a>
+      </h4>
     </div>
+    <div id="{{category.key}}" class="panel-collapse collapse facet-types {{category.displayState}}">
+      <div class="panel-body">
+        <div ng-repeat="item in category.list">
+          <div>
+            <a href="javascript:;" ng-click="vm.applyCollection(item)" class="underline ng-scope">
+              <span class="text ng-binding">
+                {{item.title}}
+                <span class="facet_count ng-binding" aria-hidden="false"> ({{item.count}} items)</span>
+              </span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </section>

--- a/app/src/home/quick-links.html
+++ b/app/src/home/quick-links.html
@@ -1,18 +1,18 @@
 <section class="quick-links collections col-md-3 col-sm-4 col-xs-12 pull-right">
   <header>
-    <h1>{{vm.title}}</h1>
+    <h1>{{$ctrl.title}}</h1>
   </header>
-  <ul ng-if="vm.categories.length == 0">
-    <li ng-repeat="item in ::vm.list">
-      <a href="javascript:;" class="icon-collection" ng-click="vm.applyCollection(item)">
+  <ul ng-if="$ctrl.categories.length == 0">
+    <li ng-repeat="item in ::$ctrl.list">
+      <a href="javascript:;" class="icon-collection" ng-click="$ctrl.applyCollection(item)">
         {{::item.title}}<span>{{::item.count | number}} item{{::item.count > 1 ? "s" : ""}}</span>
       </a>
     </li>
   </ul>
-  <div ng-if="vm.categories.length > 0" class="panel panel-primary" ng-repeat="category in vm.categories" aria-hidden="false">
+  <div ng-if="$ctrl.categories.length > 0" class="panel panel-primary" ng-repeat="category in $ctrl.categories" aria-hidden="false">
     <div class="panel-heading" ng-class="category.displayState == 'in' ? 'selected' : ''">
       <h4 class="panel-title">
-        <a data-toggle="collapse" target="_self" href="#{{category.key}}" ng-click="vm.toggleDisplayState(category)">
+        <a data-toggle="collapse" target="_self" href="#{{category.key}}" ng-click="$ctrl.toggleDisplayState(category)">
           {{category.key}} <i class="fa" ng-class="category.displayState == 'in' ? 'fa-angle-up' : 'fa-angle-down'"></i>
         </a>
       </h4>
@@ -21,7 +21,7 @@
       <div class="panel-body">
         <div ng-repeat="item in category.list">
           <div>
-            <a href="javascript:;" ng-click="vm.applyCollection(item)" class="underline ng-scope">
+            <a href="javascript:;" ng-click="$ctrl.applyCollection(item)" class="underline ng-scope">
               <span class="text ng-binding">
                 {{item.title}}
                 <span class="facet_count ng-binding" aria-hidden="false"> ({{item.count}} items)</span>

--- a/app/src/home/quick-links.ts
+++ b/app/src/home/quick-links.ts
@@ -11,6 +11,7 @@ namespace VoyagerHome {
       list: '<'
     };
     controller = Controller;
+    controllerAs = 'vm';
   }
 
   class Controller {

--- a/app/src/home/quick-links.ts
+++ b/app/src/home/quick-links.ts
@@ -11,7 +11,6 @@ namespace VoyagerHome {
       list: '<'
     };
     controller = Controller;
-    controllerAs = 'vm';
   }
 
   class Controller {


### PR DESCRIPTION
Removed controllerAs='vm' and related